### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bite-frontend/bsconfig.json
+++ b/bite-frontend/bsconfig.json
@@ -11,7 +11,7 @@
     "reason-react",
     "bs-css",
     "@glennsl/bs-json",
-    "@aantron/repromise",
+    "reason-promise",
     "re-classnames",
     "bs-fetch",
     "bs-webapi",

--- a/bite-frontend/package.json
+++ b/bite-frontend/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@aantron/repromise": "^0.6.1",
     "@glennsl/bs-json": "^5.0.1",
     "@jsiebern/bs-material-ui": "1.1.0-hooks.3",
     "@material-ui/core": "3.9.2",
@@ -17,10 +16,11 @@
     "re-formality": "^3.2.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.7.0"
   },
   "devDependencies": {
-    "bs-platform": "^5.0.6",
+    "bs-platform": "7.0.1",
     "bsb-js": "^1.1.7",
     "npm-run-all": "^4.1.5",
     "parcel-bundler": "^1.12.3"

--- a/bite-frontend/src/infrastructure/RestApi.re
+++ b/bite-frontend/src/infrastructure/RestApi.re
@@ -2,26 +2,26 @@ let apiUrl = "https://bitehack.codeheroes.tech";
 
 let fetch = (path: string, params) =>
   Fetch.fetchWithInit(apiUrl ++ path, params)
-  |> Repromise.Rejectable.fromJsPromise
-  |> Repromise.Rejectable.andThen(res => {
+  ->Promise.Js.fromBsPromise
+  ->Promise.Js.flatMap(res => {
        let status = Fetch.Response.status(res);
        switch (status) {
        | 200
        | 201 =>
          Fetch.Response.json(res)
-         |> Repromise.Rejectable.fromJsPromise
-         |> Repromise.Rejectable.map(json => Belt.Result.Ok(json))
+         ->Promise.Js.fromBsPromise
+         ->Promise.Js.map(json => Belt.Result.Ok(json))
 
        | status =>
          Fetch.Response.text(res)
-         |> Repromise.Rejectable.fromJsPromise
-         |> Repromise.Rejectable.map(text =>
+         ->Promise.Js.fromBsPromise
+         ->Promise.Js.map(text =>
               Belt.Result.Error(`Error((status, text)))
             )
        };
      })
-  |> Repromise.Rejectable.catch(error =>
-       Belt.Result.Error(`Exception(error)) |> Repromise.resolved
+  ->Promise.Js.catch(error =>
+       Belt.Result.Error(`Exception(error))->Promise.resolved
      );
 
 module JsonData = {

--- a/bite-frontend/src/views/IssueForm.re
+++ b/bite-frontend/src/views/IssueForm.re
@@ -270,7 +270,7 @@ let make = (~state: FormConfig.state) => {
         },
         (),
       )
-      |> Repromise.Rejectable.wait(result => {
+      ->Promise.Js.get(result => {
            Js.log(result);
 
            MessengerExtensions.closeWindow("facebook", error =>

--- a/bite-frontend/yarn.lock
+++ b/bite-frontend/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@aantron/repromise@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@aantron/repromise/-/repromise-0.6.1.tgz#5ad99cba57f5a4a88783b833ef2a3d2d9dfdba2f"
-  integrity sha512-dHWAWTlpPQCZcN9sCOzljOcMCD7ipQgLE1NOA3CszUxS3FKCl7muave235AX/waV5V6KqRFscg0iQVz2phZTNA==
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -1375,10 +1370,10 @@ bs-fetch@^0.5.0:
   resolved "https://registry.yarnpkg.com/bs-fetch/-/bs-fetch-0.5.0.tgz#6913b1d1ddfa0b0a4b832357854e9763d61d4b28"
   integrity sha512-cGjwRpyNcIaX+p2ssy/38zs7BM/miKNgmOR3NEhxKFete5mR05JcvjuV4raG89oGCG281SU1b56TTAKmf9VCug==
 
-bs-platform@^5.0.6:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
+bs-platform@7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.1.tgz#1d7b0ef6088b998dceee5db74a7cd8f01c20a3bd"
+  integrity sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==
 
 bs-webapi@^0.15.3:
   version "0.15.4"
@@ -4834,6 +4829,11 @@ readdirp@^2.2.1:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 reason-react@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
Repromise became [reason-promise](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.